### PR TITLE
발견 게시글 생성 이후 로직 추가/마이페이지 기능 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   backend:
     build: ../goldangtime
-    image: zyerin/goldaeng:latest
+    image: goldengtime-docker/backend:latest
     ports:
       - "8080:8080"
     environment:

--- a/src/main/java/com/goldang/goldangtime/config/SecurityConfig.java
+++ b/src/main/java/com/goldang/goldangtime/config/SecurityConfig.java
@@ -23,24 +23,18 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-        return httpSecurity
-                .httpBasic().disable()
-                .csrf().disable()
-                .sessionManagement()
-                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
-                .authorizeHttpRequests()
-                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html") // Swagger UI 경로 허용
-                    .permitAll()
-                    .anyRequest().authenticated()
-                .and()
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
-                .build();
+        return httpSecurity.httpBasic((hp)->hp.disable())
+                .csrf((cs)->cs.disable())
+                .sessionManagement((sm)->sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests((ahr)->ahr.requestMatchers("/user/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll())
+                // JWT 인증을 위하여 직접 구현한 필터를 UsernamePasswordAuthenticationFilter 전에 실행
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class).build();
     }
-    
+
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();  // 비밀번호 암호화에 BCrypt 사용
+        // BCrypt Encoder 사용
+        return new BCryptPasswordEncoder();
     }
 
     @Bean

--- a/src/main/java/com/goldang/goldangtime/controller/AnimalController.java
+++ b/src/main/java/com/goldang/goldangtime/controller/AnimalController.java
@@ -1,5 +1,0 @@
-package com.goldang.goldangtime.controller;
-
-public class AnimalController {
-    
-}

--- a/src/main/java/com/goldang/goldangtime/controller/FoundPostController.java
+++ b/src/main/java/com/goldang/goldangtime/controller/FoundPostController.java
@@ -7,6 +7,7 @@ import com.goldang.goldangtime.service.FoundPostService;
 
 import com.goldang.goldangtime.service.MatchingService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.io.IOException;
@@ -46,11 +47,18 @@ public class FoundPostController {
     public List<FoundPostDto> getAllFoundPosts(){
         return foundPostService.getAllFoundPosts();
     }
-    
+
     @PostMapping
-    @Operation(summary =  "FoundPost 생성")
-    public FoundPostDto createdFoundPost(@RequestBody FoundPostDto foundPostDTO) {
-        return foundPostService.createFoundPost(foundPostDTO);
+    @Operation(summary = "FoundPost 생성")
+    public ResponseEntity<?> createdFoundPost(@RequestBody FoundPostDto foundPostDTO) {
+        try {
+            FoundPostDto createdPost = foundPostService.createFoundPost(foundPostDTO);
+            return ResponseEntity.ok(createdPost);
+        } catch (IOException e) {
+            // 오류 처리
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Failed to create FoundPost: " + e.getMessage());
+        }
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/goldang/goldangtime/controller/MyPageController.java
+++ b/src/main/java/com/goldang/goldangtime/controller/MyPageController.java
@@ -1,2 +1,53 @@
-package com.goldang.goldangtime.controller;public class MypageController {
+package com.goldang.goldangtime.controller;
+
+import com.goldang.goldangtime.dto.MyPageResponseDto;
+import com.goldang.goldangtime.dto.ProfileRequestDto;
+import com.goldang.goldangtime.entity.Comment;
+import com.goldang.goldangtime.entity.Users;
+import com.goldang.goldangtime.service.MyPageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+    private final MyPageService myPageService;
+
+    // 프로필 수정
+    @PostMapping("/{userId}/profile")
+    public ResponseEntity<Users> updateProfile(@PathVariable Long userId, @RequestBody ProfileRequestDto myPageDto) {
+        String nickname = myPageDto.getNickname();
+        String userPhoto = myPageDto.getUserPhoto();
+        log.info("Update Profile for {}: ", nickname);
+
+        Users updatedUser = myPageService.updateProfile(userId, nickname, userPhoto);
+        return ResponseEntity.ok(updatedUser);
+    }
+
+    // 내가 쓴 글 조회 (LostPost, FoundPost 포함)
+    @GetMapping("/{userId}/posts")
+    public ResponseEntity<List<MyPageResponseDto>> getUserPosts(@PathVariable Long userId) {
+        List<MyPageResponseDto> userPosts = myPageService.getUserPosts(userId);
+        return ResponseEntity.ok(userPosts);
+    }
+
+    // 내가 쓴 댓글 조회
+    @GetMapping("/{userId}/comments")
+    public ResponseEntity<List<Comment>> getUserComments(@PathVariable Long userId) {
+        List<Comment> userComments = myPageService.getUserComments(userId);
+        return ResponseEntity.ok(userComments);
+    }
+
+    // 내가 스크랩한 글 조회
+    @GetMapping("/{userId}/scraps")
+    public ResponseEntity<List<MyPageResponseDto>> getUserScraps(@PathVariable Long userId) {
+        List<MyPageResponseDto> scraps = myPageService.getUserScraps(userId);
+        return ResponseEntity.ok(scraps);
+    }
 }

--- a/src/main/java/com/goldang/goldangtime/controller/MyPageController.java
+++ b/src/main/java/com/goldang/goldangtime/controller/MyPageController.java
@@ -1,0 +1,2 @@
+package com.goldang.goldangtime.controller;public class MypageController {
+}

--- a/src/main/java/com/goldang/goldangtime/controller/ScrapController.java
+++ b/src/main/java/com/goldang/goldangtime/controller/ScrapController.java
@@ -1,2 +1,26 @@
-package com.goldang.goldangtime.controller;public class ScrapController {
+package com.goldang.goldangtime.controller;
+
+import com.goldang.goldangtime.service.ScrapService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/scrap")
+@RequiredArgsConstructor
+public class ScrapController {
+
+    private final ScrapService scrapService;
+
+    @PostMapping("/lost-post/{lostPostId}")
+    public ResponseEntity<String> scrapLostPost(@RequestParam Long userId, @PathVariable Long lostPostId) {
+        scrapService.scrapLostPost(userId, lostPostId);
+        return ResponseEntity.ok(String.format("Scrap lost post successfully: %d", lostPostId));
+    }
+
+    @PostMapping("/found-post/{foundPostId}")
+    public ResponseEntity<String> scrapFoundPost(@RequestParam Long userId, @PathVariable Long foundPostId) {
+        scrapService.scrapFoundPost(userId, foundPostId);
+        return ResponseEntity.ok(String.format("Scrap found post successfully: %d", foundPostId));
+    }
 }

--- a/src/main/java/com/goldang/goldangtime/controller/ScrapController.java
+++ b/src/main/java/com/goldang/goldangtime/controller/ScrapController.java
@@ -1,0 +1,2 @@
+package com.goldang.goldangtime.controller;public class ScrapController {
+}

--- a/src/main/java/com/goldang/goldangtime/dto/MyPageResponseDto.java
+++ b/src/main/java/com/goldang/goldangtime/dto/MyPageResponseDto.java
@@ -1,2 +1,17 @@
-package com.goldang.goldangtime.dto;public class MyPageResponseDto {
+package com.goldang.goldangtime.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class MyPageResponseDto {
+    private Long id;           // 게시글 ID
+    private String type;       // 게시글 유형 ("LostPost" 또는 "FoundPost")
+    private String title;
+    private String description;
+    private String photo;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/goldang/goldangtime/dto/MyPageResponseDto.java
+++ b/src/main/java/com/goldang/goldangtime/dto/MyPageResponseDto.java
@@ -1,0 +1,2 @@
+package com.goldang.goldangtime.dto;public class MyPageResponseDto {
+}

--- a/src/main/java/com/goldang/goldangtime/dto/ProfileRequestDto.java
+++ b/src/main/java/com/goldang/goldangtime/dto/ProfileRequestDto.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class MyPageDto {
+public class ProfileRequestDto {
     private String nickname;
     private String userPhoto;
 }

--- a/src/main/java/com/goldang/goldangtime/dto/ProfileRequestDto.java
+++ b/src/main/java/com/goldang/goldangtime/dto/ProfileRequestDto.java
@@ -1,0 +1,11 @@
+package com.goldang.goldangtime.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MyPageDto {
+    private String nickname;
+    private String userPhoto;
+}

--- a/src/main/java/com/goldang/goldangtime/entity/Scrap.java
+++ b/src/main/java/com/goldang/goldangtime/entity/Scrap.java
@@ -1,2 +1,30 @@
-package com.goldang.goldangtime.entity;public class Scrap {
+package com.goldang.goldangtime.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "scrap")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Scrap {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @ManyToOne
+    @JoinColumn(name = "lost_post_id", nullable = true) // LostPost에 대한 스크랩
+    private LostPost lostPost;
+
+    @ManyToOne
+    @JoinColumn(name = "found_post_id", nullable = true) // FoundPost에 대한 스크랩
+    private FoundPost foundPost;
 }

--- a/src/main/java/com/goldang/goldangtime/entity/Scrap.java
+++ b/src/main/java/com/goldang/goldangtime/entity/Scrap.java
@@ -1,0 +1,2 @@
+package com.goldang.goldangtime.entity;public class Scrap {
+}

--- a/src/main/java/com/goldang/goldangtime/entity/Users.java
+++ b/src/main/java/com/goldang/goldangtime/entity/Users.java
@@ -35,4 +35,6 @@ public class Users {
     @Column(name = "fcm_token")
     private String fcmToken;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Scrap> scraps = new ArrayList<>();
 }

--- a/src/main/java/com/goldang/goldangtime/repository/CommentRepository.java
+++ b/src/main/java/com/goldang/goldangtime/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.goldang.goldangtime.repository;
 
 import com.goldang.goldangtime.entity.Comment;
+import com.goldang.goldangtime.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,6 +9,7 @@ import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByUser(Users user);
 
     // LostPost의 최상위 댓글 조회
     List<Comment> findAllByLostPostIdAndParentCommentIsNull(Long lostPostId);

--- a/src/main/java/com/goldang/goldangtime/repository/FoundPostRepository.java
+++ b/src/main/java/com/goldang/goldangtime/repository/FoundPostRepository.java
@@ -1,5 +1,7 @@
 package com.goldang.goldangtime.repository;
 
+import com.goldang.goldangtime.entity.LostPost;
+import com.goldang.goldangtime.entity.Users;
 import org.springframework.stereotype.Repository;
 import com.goldang.goldangtime.entity.FoundPost;
 import java.util.List;
@@ -8,5 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 @Repository
 public interface FoundPostRepository extends JpaRepository<FoundPost, Long> {
+    List<FoundPost> findAllByUser(Users user);
     List<FoundPost> findByUserId(Long userId); // 사용자가 작성한 게시글 목록 조회
 }

--- a/src/main/java/com/goldang/goldangtime/repository/LostPostRepository.java
+++ b/src/main/java/com/goldang/goldangtime/repository/LostPostRepository.java
@@ -1,6 +1,7 @@
 package com.goldang.goldangtime.repository;
 
 import com.goldang.goldangtime.entity.LostPost;
+import com.goldang.goldangtime.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import org.springframework.stereotype.Repository;
@@ -8,5 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface LostPostRepository extends JpaRepository<LostPost, Long> {
     List<LostPost> findByUserId(Long userId); // 사용자가 작성한 게시글 목록 조회
+    List<LostPost> findAllByUser(Users user);
 }
 

--- a/src/main/java/com/goldang/goldangtime/repository/ScrapRepository.java
+++ b/src/main/java/com/goldang/goldangtime/repository/ScrapRepository.java
@@ -1,0 +1,2 @@
+package com.goldang.goldangtime.repository;public class ScrapRepository {
+}

--- a/src/main/java/com/goldang/goldangtime/repository/ScrapRepository.java
+++ b/src/main/java/com/goldang/goldangtime/repository/ScrapRepository.java
@@ -1,2 +1,13 @@
-package com.goldang.goldangtime.repository;public class ScrapRepository {
+package com.goldang.goldangtime.repository;
+
+import com.goldang.goldangtime.entity.Scrap;
+import com.goldang.goldangtime.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ScrapRepository extends JpaRepository<Scrap, Long> {
+    boolean existsByUserIdAndLostPostId(Long userId, Long lostPostId);
+    boolean existsByUserIdAndFoundPostId(Long userId, Long foundPostId);
+    List<Scrap> findAllByUser(Users user);
 }

--- a/src/main/java/com/goldang/goldangtime/service/CustomUserDetailsService.java
+++ b/src/main/java/com/goldang/goldangtime/service/CustomUserDetailsService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {

--- a/src/main/java/com/goldang/goldangtime/service/FoundPostService.java
+++ b/src/main/java/com/goldang/goldangtime/service/FoundPostService.java
@@ -22,6 +22,7 @@ public class FoundPostService {
 
     private final FoundPostRepository foundPostRepository;
     private final UserService userService;
+    private final MatchingService matchingService;
 
     public List<FoundPostDto> getAllFoundPosts() {
         return foundPostRepository.findAll()
@@ -39,9 +40,14 @@ public class FoundPostService {
 
     // 발견된 게시글 생성
     @Transactional
-    public FoundPostDto createFoundPost(FoundPostDto foundPostDTO) {
+    public FoundPostDto createFoundPost(FoundPostDto foundPostDTO) throws IOException {
         FoundPost foundPost = convertToEntity(foundPostDTO);
-        return convertToDTO(foundPostRepository.save(foundPost));
+        FoundPost savedPost = foundPostRepository.save(foundPost);
+
+        // 발견된 게시글 생성 후 유사도 비교 및 매칭 저장
+        matchingService.compareAndSaveMatches(savedPost);
+
+        return convertToDTO(savedPost);
     }
 
     // 엔티티를 DTO로 변환

--- a/src/main/java/com/goldang/goldangtime/service/MyPageService.java
+++ b/src/main/java/com/goldang/goldangtime/service/MyPageService.java
@@ -1,4 +1,109 @@
 package com.goldang.goldangtime.service;
 
+import com.goldang.goldangtime.dto.MyPageResponseDto;
+import com.goldang.goldangtime.entity.Comment;
+import com.goldang.goldangtime.entity.LostPost;
+import com.goldang.goldangtime.entity.Scrap;
+import com.goldang.goldangtime.entity.Users;
+import com.goldang.goldangtime.repository.*;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
 public class MyPageService {
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+    private final LostPostRepository lostPostRepository;
+    private final FoundPostRepository foundPostRepository;
+    private final ScrapRepository scrapRepository;
+
+    // 프로필 수정
+    @Transactional
+    public Users updateProfile(Long userId, String nickname, String userPhoto) {
+        // 사용자 조회
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with ID: " + userId));
+
+        // 닉네임과 프로필 사진 수정
+        user.setNickname(nickname);
+        user.setUserPhoto(userPhoto);
+
+        return userRepository.save(user);
+    }
+
+    // 사용자가 작성한 글 조회 -> MyPageResponseDto 반환
+    public List<MyPageResponseDto> getUserPosts(Long userId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // 사용자가 작성한 LostPost 조회 및 변환
+        List<MyPageResponseDto> lostPosts = lostPostRepository.findAllByUser(user).stream()
+                .map(this::convertLostPostToDto)
+                .collect(Collectors.toList());
+
+        // 사용자가 작성한 FoundPost 조회 및 변환
+        List<MyPageResponseDto> foundPosts = foundPostRepository.findAllByUser(user).stream()
+                .map(this::convertFoundPostToDto)
+                .collect(Collectors.toList());
+
+        // LostPost와 FoundPost 리스트 합치기
+        lostPosts.addAll(foundPosts);
+
+        return lostPosts;
+    }
+
+
+    // 사용자가 쓴 댓글 조회
+    public List<Comment> getUserComments(Long userId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        return commentRepository.findAllByUser(user);
+    }
+
+    // 사용자가 스크랩한 게시글 조회 -> MyPageResponseDto 반환
+    public List<MyPageResponseDto> getUserScraps(Long userId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        List<Scrap> scraps = scrapRepository.findAllByUser(user);
+
+        return scraps.stream()
+                .map(scrap -> {
+                    if (scrap.getLostPost() != null) {
+                        return convertLostPostToDto(scrap.getLostPost());
+                    } else {
+                        return convertFoundPostToDto(scrap.getFoundPost());
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    // LostPost를 MyPageResponseDto로 변환
+    private MyPageResponseDto convertLostPostToDto(LostPost lostPost) {
+        return MyPageResponseDto.builder()
+                .id(lostPost.getId())
+                .type("LostPost")
+                .title(lostPost.getTitle())
+                .description(lostPost.getDescription())
+                .photo(lostPost.getLostPhoto())
+                .createdAt(lostPost.getCreatedAt())
+                .build();
+    }
+
+    // FoundPost를 MyPageResponseDto로 변환
+    private MyPageResponseDto convertFoundPostToDto(com.goldang.goldangtime.entity.FoundPost foundPost) {
+        return MyPageResponseDto.builder()
+                .id(foundPost.getId())
+                .type("FoundPost")
+                .title(foundPost.getTitle())
+                .description(foundPost.getDescription())
+                .photo(foundPost.getFoundPhoto())
+                .createdAt(foundPost.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/goldang/goldangtime/service/ScrapService.java
+++ b/src/main/java/com/goldang/goldangtime/service/ScrapService.java
@@ -1,0 +1,2 @@
+package com.goldang.goldangtime.service;public class ScrapService {
+}

--- a/src/main/java/com/goldang/goldangtime/service/ScrapService.java
+++ b/src/main/java/com/goldang/goldangtime/service/ScrapService.java
@@ -1,2 +1,67 @@
-package com.goldang.goldangtime.service;public class ScrapService {
+package com.goldang.goldangtime.service;
+
+import com.goldang.goldangtime.entity.*;
+import com.goldang.goldangtime.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ScrapService {
+
+    private final ScrapRepository scrapRepository;
+    private final LostPostRepository lostPostRepository;
+    private final FoundPostRepository foundPostRepository;
+
+    @Transactional
+    public void scrapLostPost(Long userId, Long lostPostId) {
+        // 스크랩 중복 확인
+        if (scrapRepository.existsByUserIdAndLostPostId(userId, lostPostId)) {
+            throw new IllegalArgumentException("이미 스크랩한 게시글입니다.");
+        }
+
+        // 사용자와 게시글 조회
+        LostPost lostPost = lostPostRepository.findById(lostPostId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 실종 게시글을 찾을 수 없습니다."));
+        Users user = lostPost.getUser();
+
+        // Scrap 생성
+        Scrap scrap = createScrap(user, lostPost, null);
+        scrapRepository.save(scrap);
+
+        // 게시글 스크랩 수 증가
+        lostPost.setScrap(lostPost.getScrap() + 1);
+        lostPostRepository.save(lostPost);
+    }
+
+    @Transactional
+    public void scrapFoundPost(Long userId, Long foundPostId) {
+        // 스크랩 중복 확인
+        if (scrapRepository.existsByUserIdAndFoundPostId(userId, foundPostId)) {
+            throw new IllegalArgumentException("이미 스크랩한 게시글입니다.");
+        }
+
+        // 사용자와 게시글 조회
+        FoundPost foundPost = foundPostRepository.findById(foundPostId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 발견 게시글을 찾을 수 없습니다."));
+        Users user = foundPost.getUser();
+
+        // Scrap 생성
+        Scrap scrap = createScrap(user, null, foundPost);
+        scrapRepository.save(scrap);
+
+        // 게시글 스크랩 수 증가
+        foundPost.setScrap(foundPost.getScrap() + 1);
+        foundPostRepository.save(foundPost);
+    }
+
+    // scrap 엔티티 생성
+    private Scrap createScrap(Users user, LostPost lostPost, FoundPost foundPost) {
+        return Scrap.builder()
+                .user(user)
+                .lostPost(lostPost) // 실종 게시글
+                .foundPost(foundPost) // 발견 게시글
+                .build();
+    }
 }

--- a/src/main/java/com/goldang/goldangtime/service/UserService.java
+++ b/src/main/java/com/goldang/goldangtime/service/UserService.java
@@ -42,6 +42,7 @@ public class UserService {
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
         log.info("Passed signIn 1");
 
+        // AuthenticationManager에서 CustomUserDetailsService의 loadUserByUsername을 호출
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
         log.info("Passed signIn 2");
 


### PR DESCRIPTION
### 발견 게시글 생성 이후 로직
1. 모든 실종 게시글과의 유사도 계산 후 Matching 엔티티 생성 후 저장
2. 유사도가 0.85 이상이면 해당 실종 게시글 작성자에게 푸시알림 보내는 로직 구현 -> FCM

### 마이페이지 기능 추가
1. 프로필 수정 -> nickname, userPhoto
2. 내가 쓴 글
3. 내가 작성한 댓글
4. 내가 스크랩한 글
